### PR TITLE
Fix big bug on the selector causing pointing to non-existent method

### DIFF
--- a/contracts/VoteProcessorModule.sol
+++ b/contracts/VoteProcessorModule.sol
@@ -6,7 +6,6 @@ import "@openzeppelin/contracts/utils/Strings.sol";
 import "@openzeppelin/contracts/security/Pausable.sol";
 
 import "interfaces/Gnosis/IGnosisSafe.sol";
-import "interfaces/Gnosis/ISignMessageLib.sol";
 import "interfaces/Snapshot/IProposalRegistry.sol";
 
 /*

--- a/contracts/VoteProcessorModule.sol
+++ b/contracts/VoteProcessorModule.sol
@@ -6,6 +6,7 @@ import "@openzeppelin/contracts/utils/Strings.sol";
 import "@openzeppelin/contracts/security/Pausable.sol";
 
 import "interfaces/Gnosis/IGnosisSafe.sol";
+import "interfaces/Gnosis/ISignMessageLib.sol";
 import "interfaces/Snapshot/IProposalRegistry.sol";
 
 /*
@@ -105,6 +106,11 @@ contract VoteProcessorModule is Pausable {
         _unpause();
     }
 
+    function setGovernance(address _governance) external onlyGovernance {
+        require(_governance != address(0), "zero-address!");
+        governance = _governance;
+    }
+
     /***************************************
        VOTE PROPOSAL, VALIDATION & EXEC
     ****************************************/
@@ -166,7 +172,7 @@ contract VoteProcessorModule is Pausable {
         require(proposals[proposal].approved, "not-approved!");
 
         bytes memory data = abi.encodeWithSignature(
-            "signMessage(bytes32)",
+            "signMessage(bytes)",
             hash(proposal)
         );
 
@@ -245,5 +251,16 @@ contract VoteProcessorModule is Pausable {
                     str
                 )
             );
+    }
+
+    /***************************************
+                VIEW METHODS
+    ****************************************/
+    function getProposers() public view returns (address[] memory) {
+        return _proposers.values();
+    }
+
+    function getValidators() public view returns (address[] memory) {
+        return _validators.values();
     }
 }


### PR DESCRIPTION
Fixes one err found in the production deployment regarding the selector, which was taking as argument *bytes32* instead of *bytes*. Then, it produced a pointing to a method which does not exist in the sign library. Could not spotted in the tests this issue 💀 